### PR TITLE
Add tsunami forecast support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,6 +130,14 @@ for m in "${mipmap[@]}"; do
 done
 
 
+mipmap=( 512 256 128 )
+
+for m in "${mipmap[@]}"; do
+	resvg "./tsunami-legend/legend-packed.svg" \
+		--skip-system-fonts --use-fonts-dir "$FONTS" \
+		"$TARGET/tsunami-legend-$m.png" --width "$m" --height "$m"
+done
+
 # --------------------------------
 
 simple_dirs=( branding )

--- a/tsunami-legend/advisory.svg
+++ b/tsunami-legend/advisory.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 256 64" xmlns="http://www.w3.org/2000/svg" width="256px" height="64px">
+	<line x1="8" y1="32" x2="40" y2="32" stroke="rgb(250, 245, 0)" stroke-width="6" />
+
+	<text
+		font-family="'BIZ UDPGothic'"
+		fill="#000"
+		font-size="24"
+		font-weight="700"
+		dominant-baseline="middle"
+		x="48"
+		y="53%"
+	>
+		津波注意報
+	</text>
+</svg>

--- a/tsunami-legend/forecast.svg
+++ b/tsunami-legend/forecast.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 256 64" xmlns="http://www.w3.org/2000/svg" width="256px" height="64px">
+	<line x1="8" y1="32" x2="40" y2="32" stroke="rgb(0, 191, 255)" stroke-width="6" />
+
+	<text
+		font-family="'BIZ UDPGothic'"
+		fill="#000"
+		font-size="24"
+		font-weight="700"
+		dominant-baseline="middle"
+		x="48"
+		y="53%"
+	>
+		津波予報
+	</text>
+</svg>

--- a/tsunami-legend/legend-packed.svg
+++ b/tsunami-legend/legend-packed.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" width="256px" height="256px">
+	<!-- This empty text element is must be required. -->
+	<!-- refs: https://github.com/RazrFalcon/resvg/issues/740 -->
+	<text></text>
+
+	<image x="0" y="0" width="256" height="64" href="major-warning.svg" />
+	<image x="0" y="64" width="256" height="64" href="warning.svg" />
+	<image x="0" y="128" width="256" height="64" href="advisory.svg" />
+	<image x="0" y="192" width="256" height="64" href="forecast.svg" />
+</svg>

--- a/tsunami-legend/major-warning.svg
+++ b/tsunami-legend/major-warning.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 256 64" xmlns="http://www.w3.org/2000/svg" width="256px" height="64px">
+	<line x1="8" y1="32" x2="40" y2="32" stroke="rgb(200, 0, 255)" stroke-width="6" />
+
+	<text
+		font-family="'BIZ UDPGothic'"
+		fill="#000"
+		font-size="24"
+		font-weight="700"
+		dominant-baseline="middle"
+		x="48"
+		y="53%"
+	>
+		大津波警報
+	</text>
+</svg>

--- a/tsunami-legend/warning.svg
+++ b/tsunami-legend/warning.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 256 64" xmlns="http://www.w3.org/2000/svg" width="256px" height="64px">
+	<line x1="8" y1="32" x2="40" y2="32" stroke="rgb(255, 40, 0)" stroke-width="6" />
+
+	<text
+		font-family="'BIZ UDPGothic'"
+		fill="#000"
+		font-size="24"
+		font-weight="700"
+		dominant-baseline="middle"
+		x="48"
+		y="53%"
+	>
+		津波警報
+	</text>
+</svg>


### PR DESCRIPTION
色は[ここ](https://discord.com/channels/564550533973540885/1369639724142039100/1448926613436629122)から持ってきた。

> メモ
> 大津波警報
> https://www.jma.go.jp/bosai/tsunami/images/tm.svg
> 津波警報
> https://www.jma.go.jp/bosai/tsunami/images/tw.svg
> 津波注意報
> https://www.jma.go.jp/bosai/tsunami/images/ta.svg
> 津波予報（若干の海面変動）
> https://www.jma.go.jp/bosai/tsunami/images/tf.svg

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/90fad3aa-36b0-4a0a-9f63-3f54ceb8564a" />
